### PR TITLE
Add XOR cipher module

### DIFF
--- a/frammy/cipher.py
+++ b/frammy/cipher.py
@@ -1,0 +1,13 @@
+from typing import Iterable
+
+
+def encrypt(data: bytes, key: bytes) -> bytes:
+    """Encrypt data using XOR cipher with the given key."""
+    if not key:
+        raise ValueError("Key must not be empty")
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+
+
+def decrypt(data: bytes, key: bytes) -> bytes:
+    """Decrypt data using XOR cipher with the given key."""
+    return encrypt(data, key)

--- a/tests/test_cipher.py
+++ b/tests/test_cipher.py
@@ -1,0 +1,11 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from frammy.cipher import encrypt, decrypt
+
+
+def test_encrypt_decrypt_roundtrip():
+    plaintext = b"hello world"
+    key = b"secret"
+    ciphertext = encrypt(plaintext, key)
+    assert ciphertext != plaintext
+    assert decrypt(ciphertext, key) == plaintext


### PR DESCRIPTION
## Summary
- add a simple XOR cipher implementation
- include tests for encrypt/decrypt

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b05d854c4833283bf3b9f76519156